### PR TITLE
Add map legend and popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,18 @@
         max-width: 200px;
         height: auto;
     }
+
+    .popup-commissioner {
+        display: flex;
+        align-items: flex-start;
+    }
+
+    .popup-commissioner img {
+        width: 80px;
+        height: auto;
+        margin-right: 10px;
+        border: 1px solid #ccc;
+    }
   </style>
   <link rel="stylesheet" type="text/css" href="configs/loading/loading.css" />
   <script>


### PR DESCRIPTION
## Summary
- style popup content layout
- color districts with unique renderer and include legend
- display commissioner details in map popup and fix search data
- hook up county geocode service to search address and query district

## Testing
- `node --check init.js`


------
https://chatgpt.com/codex/tasks/task_e_6889261832648332848554669f8a5557