### PR TITLE
Improve address search and legend panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
       }
 
 
-    #district-selection, #address-search {
+    #district-selection {
         margin-bottom: 20px;
     }
 
@@ -173,6 +173,62 @@
         height: auto;
         margin-right: 10px;
         border: 1px solid #ccc;
+    }
+
+    #search-widget {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        z-index: 5;
+        width: 250px;
+    }
+
+    #legend-button {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 5;
+        background: #fff;
+        border: 1px solid #ccc;
+        padding: 5px 10px;
+        cursor: pointer;
+    }
+
+    #legend-panel {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 250px;
+        background: #fff;
+        box-shadow: -2px 0 4px rgba(0,0,0,0.2);
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 4;
+        overflow-y: auto;
+        padding: 10px;
+    }
+
+    #legend-panel.open {
+        transform: translateX(0);
+    }
+
+    @media (max-width:600px) {
+        #map-container {
+            right: 0;
+        }
+        #commissioner-details-container {
+            top: auto;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            width: 100%;
+            height: 40%;
+            background-color: rgba(249,249,249,0.95);
+        }
+        #legend-panel {
+            width: 80%;
+        }
     }
   </style>
   <link rel="stylesheet" type="text/css" href="configs/loading/loading.css" />
@@ -228,16 +284,15 @@
     <header id="app-header">St. Lucie County School Board Districts</header>
     <div class="trapLinkNode" tabindex="0"></div>
     <div id="jimu-layout-manager">
-        <div id="map-container"></div>
+        <div id="map-container">
+            <div id="search-widget" class="search-container"></div>
+            <button id="legend-button">Legend</button>
+            <div id="legend-panel"><div id="legend-content"></div></div>
+        </div>
         <div id="commissioner-details-container">
             <div id="district-selection">
                 <label for="district-select">Select a District:</label>
                 <select id="district-select"></select>
-            </div>
-            <div id="address-search">
-                <label for="address-input">Search for an Address:</label>
-                <input type="text" id="address-input" placeholder="Enter an address">
-                <button id="search-button">Search</button>
             </div>
             <div id="commissioner-info">
                 <h2 id="commissioner-name"></h2>


### PR DESCRIPTION
## Summary
- add floating search widget and legend controls
- remove old address search markup and logic
- add responsive legend side panel
- enable mobile-friendly layout adjustments

## Testing
- `node -c init.js`

------
https://chatgpt.com/codex/tasks/task_e_68892faf563483328472618b1c19ecf2