### PR TITLE
Add photo markers for searched addresses

### DIFF
--- a/init.js
+++ b/init.js
@@ -15,19 +15,21 @@
     "esri/Map",
     "esri/views/MapView",
     "esri/layers/FeatureLayer",
+    "esri/layers/GraphicsLayer",
+    "esri/Graphic",
     "esri/widgets/Legend",
     "esri/widgets/Search",
     "esri/tasks/Locator"
-  ], function(Map, MapView, FeatureLayer, Legend, Search, Locator) {
+  ], function(Map, MapView, FeatureLayer, GraphicsLayer, Graphic, Legend, Search, Locator) {
     const districtRenderer = {
       type: "unique-value",
       field: "DISTRICT",
       uniqueValueInfos: [
-        { value: "1", symbol: { type: "simple-fill", color: [251, 180, 174, 0.5], outline: { color: "white", width: 1 } }, label: "District 1" },
-        { value: "2", symbol: { type: "simple-fill", color: [179, 205, 227, 0.5], outline: { color: "white", width: 1 } }, label: "District 2" },
-        { value: "3", symbol: { type: "simple-fill", color: [204, 235, 197, 0.5], outline: { color: "white", width: 1 } }, label: "District 3" },
-        { value: "4", symbol: { type: "simple-fill", color: [222, 203, 228, 0.5], outline: { color: "white", width: 1 } }, label: "District 4" },
-        { value: "5", symbol: { type: "simple-fill", color: [254, 217, 166, 0.5], outline: { color: "white", width: 1 } }, label: "District 5" }
+        { value: "1", symbol: { type: "simple-fill", color: [251, 180, 174, 0.3], outline: { color: "white", width: 1 } }, label: "District 1" },
+        { value: "2", symbol: { type: "simple-fill", color: [179, 205, 227, 0.3], outline: { color: "white", width: 1 } }, label: "District 2" },
+        { value: "3", symbol: { type: "simple-fill", color: [204, 235, 197, 0.3], outline: { color: "white", width: 1 } }, label: "District 3" },
+        { value: "4", symbol: { type: "simple-fill", color: [222, 203, 228, 0.3], outline: { color: "white", width: 1 } }, label: "District 4" },
+        { value: "5", symbol: { type: "simple-fill", color: [254, 217, 166, 0.3], outline: { color: "white", width: 1 } }, label: "District 5" }
       ]
     };
 
@@ -38,9 +40,11 @@
       popupEnabled: false
     });
 
+    const addressLayer = new GraphicsLayer();
+
     const map = new Map({
       basemap: "streets-navigation-vector",
-      layers: [districtLayer]
+      layers: [districtLayer, addressLayer]
     });
 
     const view = new MapView({
@@ -169,6 +173,31 @@
           if(commissioner){
             displayCommissioner(commissioner);
             const content = `<div class="popup-commissioner"><img src="${commissioner.image}" alt="Commissioner"><div><strong>${commissioner.name}</strong><br>${commissioner.title}<br><a href="mailto:${commissioner.email}">${commissioner.email}</a><br>${address}</div></div>`;
+            addressLayer.removeAll();
+            const photoGraphic = new Graphic({
+              geometry: point,
+              symbol: {
+                type: "picture-marker",
+                url: commissioner.image,
+                width: "40px",
+                height: "50px",
+                yoffset: 20
+              }
+            });
+            const textGraphic = new Graphic({
+              geometry: point,
+              symbol: {
+                type: "text",
+                text: `District ${district}\n${commissioner.name}`,
+                yoffset: -40,
+                color: "black",
+                haloColor: "white",
+                haloSize: "1px",
+                font: { size: 12, family: "sans-serif" }
+              }
+            });
+            addressLayer.addMany([photoGraphic, textGraphic]);
+            view.goTo({ target: point, zoom: 16 });
             view.popup.open({
               title: `District ${district}`,
               location: point,


### PR DESCRIPTION
## Summary
- update the map renderer to use more transparent polygons
- add graphics layer for searched address results
- display commissioner photo and district label at searched locations

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68896bf3fef08332be82b24c394c6746